### PR TITLE
feat(gcrypto): add Argon2id password hashing support

### DIFF
--- a/gcrypto/argon2.go
+++ b/gcrypto/argon2.go
@@ -1,0 +1,68 @@
+package gcrypto
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	argon2idSaltLen = 16
+	argon2idKeyLen  = 32
+	argon2idM       = 65536
+	argon2idT       = 1
+	argon2idP       = 4
+)
+
+func GenerateArgon2idHash(password string) (string, error) {
+	salt := make([]byte, argon2idSaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("failed to generate salt: %w", err)
+	}
+
+	hash := argon2.IDKey([]byte(password), salt, argon2idT, argon2idM, argon2idP, argon2idKeyLen)
+
+	saltB64 := base64.RawStdEncoding.EncodeToString(salt)
+	hashB64 := base64.RawStdEncoding.EncodeToString(hash)
+
+	return fmt.Sprintf("$argon2id$v=19$m=%d,t=%d,p=%d$%s$%s", argon2idM, argon2idT, argon2idP, saltB64, hashB64), nil
+}
+
+func CompareArgon2idHash(hashedPassword, password string) error {
+	parts := strings.Split(hashedPassword, "$")
+	if len(parts) != 6 {
+		return fmt.Errorf("invalid hash format")
+	}
+
+	if parts[1] != "argon2id" || parts[2] != "v=19" {
+		return fmt.Errorf("unsupported argon2id version")
+	}
+
+	var m, t, p int
+	_, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &m, &t, &p)
+	if err != nil {
+		return fmt.Errorf("invalid parameters: %w", err)
+	}
+
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return fmt.Errorf("invalid salt: %w", err)
+	}
+
+	expectedHash, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return fmt.Errorf("invalid hash: %w", err)
+	}
+
+	actualHash := argon2.IDKey([]byte(password), salt, uint32(t), argon2idM, uint8(p), uint32(len(expectedHash)))
+
+	if subtle.ConstantTimeCompare(expectedHash, actualHash) != 1 {
+		return fmt.Errorf("password mismatch")
+	}
+
+	return nil
+}

--- a/gcrypto/argon2_test.go
+++ b/gcrypto/argon2_test.go
@@ -1,0 +1,67 @@
+package gcrypto
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateArgon2idHash(t *testing.T) {
+	hash, err := GenerateArgon2idHash("password")
+	if err != nil {
+		t.Fatalf("GenerateArgon2idHash failed: %v", err)
+	}
+
+	if !strings.HasPrefix(hash, "$argon2id$v=19$m=65536,t=1,p=4$") {
+		t.Errorf("unexpected hash format: %s", hash)
+	}
+}
+
+func TestCompareArgon2idHash_Success(t *testing.T) {
+	hash, err := GenerateArgon2idHash("password")
+	if err != nil {
+		t.Fatalf("GenerateArgon2idHash failed: %v", err)
+	}
+
+	err = CompareArgon2idHash(hash, "password")
+	if err != nil {
+		t.Errorf("CompareArgon2idHash should succeed for correct password: %v", err)
+	}
+}
+
+func TestCompareArgon2idHash_WrongPassword(t *testing.T) {
+	hash, err := GenerateArgon2idHash("password")
+	if err != nil {
+		t.Fatalf("GenerateArgon2idHash failed: %v", err)
+	}
+
+	err = CompareArgon2idHash(hash, "wrongpassword")
+	if err == nil {
+		t.Errorf("CompareArgon2idHash should fail for wrong password")
+	}
+}
+
+func TestCompareArgon2idHash_EmptyPassword(t *testing.T) {
+	hash, err := GenerateArgon2idHash("password")
+	if err != nil {
+		t.Fatalf("GenerateArgon2idHash failed: %v", err)
+	}
+
+	err = CompareArgon2idHash(hash, "")
+	if err == nil {
+		t.Errorf("CompareArgon2idHash should fail for empty password")
+	}
+}
+
+func TestGenerateArgon2idHash_SpecialChars(t *testing.T) {
+	passwords := []string{"密码", "🔐🔑", "!@#$%^&*()"}
+	for _, pwd := range passwords {
+		hash, err := GenerateArgon2idHash(pwd)
+		if err != nil {
+			t.Fatalf("GenerateArgon2idHash failed for %s: %v", pwd, err)
+		}
+		err = CompareArgon2idHash(hash, pwd)
+		if err != nil {
+			t.Errorf("CompareArgon2idHash failed for %s: %v", pwd, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add Argon2id password hashing support to gcrypto
- Provides `GenerateArgon2idHash` and `CompareArgon2idHash` functions
- Uses default parameters (m=65536, t=1, p=4, keyLen=32)
- Follows existing bcrypt API style

## Usage
```go
hash, _ := gcrypto.GenerateArgon2idHash("password")
err := gcrypto.CompareArgon2idHash(hash, "password")
```