### PR TITLE
refactor: replace custom cause() with gerror.Cause() for non-gerror errors

### DIFF
--- a/biz/gcontext/gincontext/render.go
+++ b/biz/gcontext/gincontext/render.go
@@ -56,18 +56,8 @@ func buildErrorResponse(ctx *gin.Context, err error) gcontext.ResponseRender {
 		r.SetMsg(gErr.Msg)
 	} else {
 		r.SetCode(-1)
-		r.SetMsg(cause(err).Error())
+		r.SetMsg(gerror.Cause(err).Error())
 	}
 	r.SetData(gin.H{})
 	return r
-}
-
-func cause(err error) error {
-	for {
-		unwrapped := errors.Unwrap(err)
-		if unwrapped == nil {
-			return err
-		}
-		err = unwrapped
-	}
 }


### PR DESCRIPTION
非 `gerror.Error` 类型的错误，使用 `gerror.Cause(err).Error()` 替代手写的 `cause()` 函数，获取最底层的根因错误消息。