### PR TITLE
refactor(configkv): migrate store layer to gormdao.Dao and extract encrypted create

### DIFF
--- a/configkv/admin.go
+++ b/configkv/admin.go
@@ -33,26 +33,36 @@ func (a *AdminAPI) Create(ctx context.Context, req *CreateReq) error {
 		status = Status(req.Status)
 	}
 
+	encryptionMode := EncryptionModePlain
 	if req.Encrypted {
-		return a.store.SetEncrypted(ctx, req.Group, req.Key, valueType, req.Value)
+		encryptionMode = EncryptionModeEncrypted
+	}
+
+	value := req.Value
+	if req.Encrypted {
+		ciphertext, err := a.store.crypto.Encrypt(req.Value)
+		if err != nil {
+			return err
+		}
+		value = ciphertext
 	}
 
 	entity := &ConfigEntity{
 		GroupName:      req.Group,
 		Key:            req.Key,
 		ValueType:      valueType,
-		Value:          req.Value,
-		EncryptionMode: EncryptionModePlain,
+		Value:          value,
+		EncryptionMode: encryptionMode,
 		Status:         status,
 		Description:    req.Description,
 	}
 
-	return a.store.db.WithContext(ctx).Save(entity).Error
+	return a.store.Set(ctx, entity)
 }
 
 func (a *AdminAPI) Update(ctx context.Context, id uint, req *UpdateReq) error {
-	var entity ConfigEntity
-	if err := a.store.db.WithContext(ctx).Where("id = ?", id).First(&entity).Error; err != nil {
+	entity, err := a.store.GetByID(ctx, id)
+	if err != nil {
 		return err
 	}
 
@@ -89,21 +99,20 @@ func (a *AdminAPI) Update(ctx context.Context, id uint, req *UpdateReq) error {
 		return nil
 	}
 
-	return a.store.db.WithContext(ctx).Model(&ConfigEntity{}).Where("id = ?", id).Updates(updateMap).Error
+	return a.store.UpdateByID(ctx, id, updateMap)
 }
 
 func (a *AdminAPI) Delete(ctx context.Context, id uint) error {
-	return a.store.db.WithContext(ctx).Where("id = ?", id).Delete(&ConfigEntity{}).Error
+	return a.store.DeleteByID(ctx, id)
 }
 
 func (a *AdminAPI) GetByID(ctx context.Context, id uint) (*ConfigInfo, error) {
-	var entity ConfigEntity
-	err := a.store.db.WithContext(ctx).Where("id = ?", id).First(&entity).Error
+	entity, err := a.store.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	cfg, err := a.store.Get(ctx, entity.GroupName, entity.Key)
+	decrypted, err := a.store.Get(ctx, entity.GroupName, entity.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +122,7 @@ func (a *AdminAPI) GetByID(ctx context.Context, id uint) (*ConfigInfo, error) {
 		GroupName:      entity.GroupName,
 		Key:            entity.Key,
 		ValueType:      entity.ValueType,
-		Value:          cfg.Value,
+		Value:          decrypted.Value,
 		EncryptionMode: entity.EncryptionMode,
 		Description:    entity.Description,
 		Status:         entity.Status,
@@ -123,26 +132,9 @@ func (a *AdminAPI) GetByID(ctx context.Context, id uint) (*ConfigInfo, error) {
 }
 
 func (a *AdminAPI) ListPage(ctx context.Context, cond *ConfigCond) (*ConfigListResp, error) {
-	var list []*ConfigEntity
-	db := a.store.db.WithContext(ctx).Model(&ConfigEntity{})
-	cond.BuildCondition(db, tableName)
-
-	var count int64
-	if err := db.Count(&count).Error; err != nil {
+	list, count, err := a.store.ListPage(ctx, cond)
+	if err != nil {
 		return nil, err
-	}
-
-	page, pageSize := cond.GetPageInfo()
-	if pageSize > 0 && page > 0 {
-		db.Offset((page - 1) * pageSize).Limit(pageSize)
-	}
-
-	if err := db.Find(&list).Error; err != nil {
-		return nil, err
-	}
-
-	for _, entity := range list {
-		a.store.decryptEntity(entity)
 	}
 
 	items := make([]*ConfigInfo, 0, len(list))
@@ -152,6 +144,7 @@ func (a *AdminAPI) ListPage(ctx context.Context, cond *ConfigCond) (*ConfigListR
 			GroupName:      entity.GroupName,
 			Key:            entity.Key,
 			ValueType:      entity.ValueType,
+			Value:          entity.Value,
 			EncryptionMode: entity.EncryptionMode,
 			Description:    entity.Description,
 			Status:         entity.Status,

--- a/configkv/kv.go
+++ b/configkv/kv.go
@@ -30,7 +30,11 @@ func New(db *gorm.DB) *kv {
 	if err != nil {
 		panic("init configkv crypto failed: " + err.Error())
 	}
-	s := newStore(db, registry, c)
+
+	getDB := func(ctx context.Context) *gorm.DB {
+		return db.WithContext(ctx)
+	}
+	s := newStore(getDB, registry, c)
 	adminAPI = newAdmin(s)
 	return &kv{store: s}
 }
@@ -103,7 +107,11 @@ func Init(db *gorm.DB) {
 		if err != nil {
 			panic("init configkv crypto failed: " + err.Error())
 		}
-		s := newStore(db, registry, c)
+
+		getDB := func(ctx context.Context) *gorm.DB {
+			return db.WithContext(ctx)
+		}
+		s := newStore(getDB, registry, c)
 		adminAPI = newAdmin(s)
 		instance = &kv{store: s}
 	})

--- a/configkv/kv_test.go
+++ b/configkv/kv_test.go
@@ -192,12 +192,9 @@ func TestMarshalValueByType(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(string(tc.valueType), func(t *testing.T) {
-			value, encrypted, err := s.marshalValue(tc.valueType, tc.val)
+			value, err := s.marshalValue(tc.valueType, tc.val)
 			if err != nil {
 				t.Fatalf("marshalValue failed: %v", err)
-			}
-			if encrypted {
-				t.Error("should not be encrypted for non-secret type")
 			}
 			if value == "" {
 				t.Error("value should not be empty")

--- a/configkv/model.go
+++ b/configkv/model.go
@@ -3,6 +3,7 @@ package configkv
 import (
 	"fmt"
 
+	"github.com/morehao/golib/dbaccess/gormdao"
 	"gorm.io/gorm"
 )
 
@@ -52,17 +53,16 @@ func (ConfigEntity) TableName() string {
 }
 
 type ConfigCond struct {
+	gormdao.BaseCond
 	Group      string
 	Key        string
 	ValueType  string
 	Status     string
-	Page       int
-	PageSize   int
-	OrderField string
 	ExactKey   bool
 }
 
 func (c *ConfigCond) BuildCondition(db *gorm.DB, tableName string) {
+	c.BaseCond.BuildCondition(db, tableName)
 	if c.Group != "" {
 		db.Where(fmt.Sprintf("%s.group_name = ?", tableName), c.Group)
 	}
@@ -79,11 +79,4 @@ func (c *ConfigCond) BuildCondition(db *gorm.DB, tableName string) {
 	if c.Status != "" {
 		db.Where(fmt.Sprintf("%s.status = ?", tableName), c.Status)
 	}
-	if c.OrderField != "" {
-		db.Order(c.OrderField)
-	}
-}
-
-func (c *ConfigCond) GetPageInfo() (page int, pageSize int) {
-	return c.Page, c.PageSize
 }

--- a/configkv/store.go
+++ b/configkv/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"gorm.io/gorm"
+	"github.com/morehao/golib/dbaccess/gormdao"
 )
 
 const (
@@ -12,107 +12,84 @@ const (
 )
 
 type store struct {
-	db            *gorm.DB
+	dbGetter      gormdao.DBGetter
+	dao           *gormdao.Dao[*ConfigEntity, []*ConfigEntity]
 	codecRegistry map[ValueType]Codec
 	crypto        *aesCrypto
 }
 
-func newStore(db *gorm.DB, codecRegistry map[ValueType]Codec, crypto *aesCrypto) *store {
+func newStore(dbGetter gormdao.DBGetter, codecRegistry map[ValueType]Codec, crypto *aesCrypto) *store {
 	return &store{
-		db:            db,
+		dbGetter:      dbGetter,
+		dao:           gormdao.NewDao[*ConfigEntity, []*ConfigEntity](tableName, "configkv", dbGetter, gormdao.WithoutSoftDelete()),
 		codecRegistry: codecRegistry,
 		crypto:        crypto,
 	}
 }
 
-func (s *store) marshalValue(valueType ValueType, val any) (string, bool, error) {
+func (s *store) marshalValue(valueType ValueType, val any) (string, error) {
 	switch valueType {
 	case ValueTypeString:
 		if v, ok := val.(string); ok {
-			return v, false, nil
+			return v, nil
 		}
-		return fmt.Sprintf("%v", val), false, nil
+		return fmt.Sprintf("%v", val), nil
 
 	case ValueTypeInt:
 		switch v := val.(type) {
 		case int:
-			return fmt.Sprintf("%d", v), false, nil
+			return fmt.Sprintf("%d", v), nil
 		case int64:
-			return fmt.Sprintf("%d", v), false, nil
+			return fmt.Sprintf("%d", v), nil
 		case int32:
-			return fmt.Sprintf("%d", v), false, nil
+			return fmt.Sprintf("%d", v), nil
 		default:
-			return "", false, fmt.Errorf("cannot convert %T to int", val)
+			return "", fmt.Errorf("cannot convert %T to int", val)
 		}
 
 	case ValueTypeBool:
 		switch v := val.(type) {
 		case bool:
-			return fmt.Sprintf("%t", v), false, nil
+			return fmt.Sprintf("%t", v), nil
 		default:
-			return "", false, fmt.Errorf("cannot convert %T to bool", val)
+			return "", fmt.Errorf("cannot convert %T to bool", val)
 		}
 
 	case ValueTypeJson, ValueTypeToml, ValueTypeYaml:
 		codec := s.codecRegistry[valueType]
 		if codec == nil {
-			return "", false, fmt.Errorf("%w: %s", errNoCodecRegistered, valueType)
+			return "", fmt.Errorf("%w: %s", errNoCodecRegistered, valueType)
 		}
 		data, err := codec.Marshal(val)
 		if err != nil {
-			return "", false, fmt.Errorf("marshal failed: %w", err)
+			return "", fmt.Errorf("marshal failed: %w", err)
 		}
-		return string(data), false, nil
+		return string(data), nil
 
 	default:
-		return "", false, errUnsupportedValueType
+		return "", errUnsupportedValueType
 	}
 }
 
-func (s *store) Set(ctx context.Context, group, key string, valueType ValueType, val any) error {
-	if group == "" || key == "" {
+func (s *store) Set(ctx context.Context, entity *ConfigEntity) error {
+	if entity.GroupName == "" || entity.Key == "" {
 		return errGroupAndKeyRequired
 	}
 
-	value, _, err := s.marshalValue(valueType, val)
-	if err != nil {
-		return err
-	}
-
-	config := ConfigEntity{
-		GroupName:      group,
-		Key:            key,
-		ValueType:      valueType,
-		Value:          value,
-		EncryptionMode: EncryptionModePlain,
-	}
-
-	err = s.db.WithContext(ctx).Save(&config).Error
-	return err
-}
-
-func (s *store) Delete(ctx context.Context, group, key string) error {
-	if group == "" || key == "" {
-		return errGroupAndKeyRequired
-	}
-	cond := &ConfigCond{Group: group, Key: key, ExactKey: true}
-	db := s.db.WithContext(ctx).Model(&ConfigEntity{})
-	cond.BuildCondition(db, tableName)
-	return db.Delete(&ConfigEntity{}).Error
+	return s.dbGetter(ctx).Table(tableName).Save(entity).Error
 }
 
 func (s *store) SetEncrypted(ctx context.Context, group, key string, valueType ValueType, val any) error {
 	if group == "" || key == "" {
 		return errGroupAndKeyRequired
 	}
-
-	value, _, err := s.marshalValue(valueType, val)
-	if err != nil {
-		return err
-	}
-
 	if s.crypto == nil {
 		return errCryptoNotConfigured
+	}
+
+	value, err := s.marshalValue(valueType, val)
+	if err != nil {
+		return err
 	}
 
 	ciphertext, err := s.crypto.Encrypt(value)
@@ -120,15 +97,15 @@ func (s *store) SetEncrypted(ctx context.Context, group, key string, valueType V
 		return fmt.Errorf("encrypt failed: %w", err)
 	}
 
-	config := ConfigEntity{
+	entity := &ConfigEntity{
 		GroupName:      group,
 		Key:            key,
 		ValueType:      valueType,
 		Value:          ciphertext,
 		EncryptionMode: EncryptionModeEncrypted,
+		Status:         StatusEnabled,
 	}
-
-	return s.db.WithContext(ctx).Save(&config).Error
+	return s.Set(ctx, entity)
 }
 
 func (s *store) Get(ctx context.Context, group, key string) (*ConfigEntity, error) {
@@ -137,16 +114,61 @@ func (s *store) Get(ctx context.Context, group, key string) (*ConfigEntity, erro
 	}
 
 	cond := &ConfigCond{Group: group, Key: key, ExactKey: true}
-	db := s.db.WithContext(ctx).Model(&ConfigEntity{})
-	cond.BuildCondition(db, tableName)
-
-	var config ConfigEntity
-	err := db.First(&config).Error
+	entity, err := s.dao.GetByCond(ctx, cond)
 	if err != nil {
+		return nil, err
+	}
+	if entity == nil || (*entity).ID == 0 {
 		return &ConfigEntity{}, nil
 	}
 
-	return s.decryptEntity(&config), nil
+	return s.decryptEntity(*entity), nil
+}
+
+func (s *store) GetByID(ctx context.Context, id uint) (*ConfigEntity, error) {
+	entity, err := s.dao.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return s.decryptEntity(*entity), nil
+}
+
+func (s *store) DeleteByGroupKey(ctx context.Context, group, key string) error {
+	if group == "" || key == "" {
+		return errGroupAndKeyRequired
+	}
+
+	cond := &ConfigCond{Group: group, Key: key, ExactKey: true}
+	entity, err := s.dao.GetByCond(ctx, cond)
+	if err != nil {
+		return err
+	}
+	if entity == nil || (*entity).ID == 0 {
+		return nil
+	}
+
+	return s.dao.Delete(ctx, (*entity).ID, 0)
+}
+
+func (s *store) DeleteByID(ctx context.Context, id uint) error {
+	return s.dao.Delete(ctx, id, 0)
+}
+
+func (s *store) UpdateByID(ctx context.Context, id uint, updateMap map[string]any) error {
+	return s.dao.UpdateMap(ctx, id, updateMap)
+}
+
+func (s *store) ListPage(ctx context.Context, cond *ConfigCond) ([]*ConfigEntity, int64, error) {
+	list, count, err := s.dao.GetPageListByCond(ctx, cond)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for _, entity := range list {
+		s.decryptEntity(entity)
+	}
+
+	return list, count, nil
 }
 
 func (s *store) decryptEntity(config *ConfigEntity) *ConfigEntity {

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -12,8 +12,8 @@ import (
 )
 
 type FileStore struct {
-	fileDao    *gormdao.Dao[File, []File]
-	uploadDao  *gormdao.Dao[FileUpload, []FileUpload]
+	fileDao    *gormdao.Dao[FileEntity, []FileEntity]
+	uploadDao  *gormdao.Dao[FileUploadEntity, []FileUploadEntity]
 	st         storage.Storage
 	bucket     string
 	signSecret string
@@ -25,14 +25,14 @@ func New(db *gorm.DB, st storage.Storage, bucket string, opts ...StoreOption) (*
 		fn(&o)
 	}
 
-	if err := db.AutoMigrate(&File{}, &FileUpload{}); err != nil {
+	if err := db.AutoMigrate(&FileEntity{}, &FileUploadEntity{}); err != nil {
 		return nil, fmt.Errorf("filestore.New: auto-migrate: %w", err)
 	}
 
 	getDB := func(ctx context.Context) *gorm.DB { return db.WithContext(ctx) }
 	return &FileStore{
-		fileDao:    gormdao.NewDao[File, []File](File{}.TableName(), "filestore.file", getDB, gormdao.WithoutSoftDelete()),
-		uploadDao:  gormdao.NewDao[FileUpload, []FileUpload](FileUpload{}.TableName(), "filestore.upload", getDB, gormdao.WithoutSoftDelete()),
+		fileDao:    gormdao.NewDao[FileEntity, []FileEntity](FileEntity{}.TableName(), "filestore.file", getDB, gormdao.WithoutSoftDelete()),
+		uploadDao:  gormdao.NewDao[FileUploadEntity, []FileUploadEntity](FileUploadEntity{}.TableName(), "filestore.upload", getDB, gormdao.WithoutSoftDelete()),
 		st:         st,
 		bucket:     bucket,
 		signSecret: o.signSecret,
@@ -69,7 +69,7 @@ func (s *FileStore) parseStorageURI(uri string) (scheme, bucket, key string, err
 	return scheme, bucket, key, nil
 }
 
-func (s *FileStore) fillFileDetail(ctx context.Context, upload *FileUpload) (*FileDetail, error) {
+func (s *FileStore) fillFileDetail(ctx context.Context, upload *FileUploadEntity) (*FileDetail, error) {
 	detail := &FileDetail{
 		FileUploadID: upload.ID,
 		CreatedAt:    upload.CreatedAt,
@@ -97,7 +97,7 @@ func (s *FileStore) fillFileDetail(ctx context.Context, upload *FileUpload) (*Fi
 	return detail, nil
 }
 
-func (s *FileStore) findOrCreateFile(ctx context.Context, contentHash string, size int64, storagePath string) (*File, error) {
+func (s *FileStore) findOrCreateFile(ctx context.Context, contentHash string, size int64, storagePath string) (*FileEntity, error) {
 	fh, err := s.fileDao.GetByCond(ctx, &fileCond{ContentHash: contentHash})
 	if err != nil {
 		return nil, fmt.Errorf("findOrCreateFile: get hash: %w", err)
@@ -106,7 +106,7 @@ func (s *FileStore) findOrCreateFile(ctx context.Context, contentHash string, si
 		return fh, nil
 	}
 
-	fh = &File{
+	fh = &FileEntity{
 		ContentHash: contentHash,
 		Size:        size,
 		StorageURI:  s.buildStorageURI(storagePath),
@@ -163,7 +163,7 @@ func (s *FileStore) RecordUpload(ctx context.Context, req RecordUploadRequest) (
 		return nil, fmt.Errorf("filestore.RecordUpload: %w", err)
 	}
 
-	upload := &FileUpload{
+	upload := &FileUploadEntity{
 		FileID:   fh.ID,
 		Name:     req.Name,
 		MimeType: req.MimeType,
@@ -191,7 +191,7 @@ func (s *FileStore) UploadAndRecord(ctx context.Context, req UploadAndRecordRequ
 			return nil, fmt.Errorf("filestore.UploadAndRecord: put object: %w", err)
 		}
 
-		fh = &File{
+		fh = &FileEntity{
 			ContentHash: req.ContentHash,
 			Size:        req.Size,
 			StorageURI:  s.buildStorageURI(req.StoragePath),
@@ -209,7 +209,7 @@ func (s *FileStore) UploadAndRecord(ctx context.Context, req UploadAndRecordRequ
 		}
 	}
 
-	upload := &FileUpload{
+	upload := &FileUploadEntity{
 		FileID:   fh.ID,
 		Name:     req.Name,
 		MimeType: req.MimeType,
@@ -298,7 +298,7 @@ func (s *FileStore) InitMultipartUpload(ctx context.Context, req InitMultipartUp
 		return nil, fmt.Errorf("filestore.InitMultipartUpload: %w", fhErr)
 	}
 
-	upload := &FileUpload{
+	upload := &FileUploadEntity{
 		FileID:   fh.ID,
 		Name:     req.Name,
 		MimeType: req.MimeType,

--- a/filestore/filestore_test.go
+++ b/filestore/filestore_test.go
@@ -108,8 +108,8 @@ func TestNewAutoMigrate(t *testing.T) {
 	fs, err := New(db, st, "test-bucket")
 	require.NoError(t, err)
 	require.NotNil(t, fs)
-	require.True(t, db.Migrator().HasTable(&File{}))
-	require.True(t, db.Migrator().HasTable(&FileUpload{}))
+	require.True(t, db.Migrator().HasTable(&FileEntity{}))
+	require.True(t, db.Migrator().HasTable(&FileUploadEntity{}))
 }
 
 func TestCheckExist_NotFound(t *testing.T) {

--- a/filestore/model.go
+++ b/filestore/model.go
@@ -20,8 +20,8 @@ const (
 	FileStatusAborted   FileStatus = "aborted"
 )
 
-// File 物理文件的元数据记录，按内容哈希去重。
-type File struct {
+// FileEntity 物理文件的元数据记录，按内容哈希去重。
+type FileEntity struct {
 	ID          uint      `gorm:"primarykey"`
 	CreatedAt   time.Time `gorm:"column:created_at;not null;autoCreateTime"`
 	UpdatedAt   time.Time `gorm:"column:updated_at;not null;autoUpdateTime"`
@@ -30,11 +30,11 @@ type File struct {
 	StorageURI  string    `gorm:"column:storage_uri;type:varchar(512);not null;default:''"`
 }
 
-func (File) TableName() string { return "core_file" }
+func (FileEntity) TableName() string { return "core_file" }
 
-// FileUpload 一次上传行为的记录，只存跟"这次上传"相关的信息。
+// FileUploadEntity 一次上传行为的记录，只存跟"这次上传"相关的信息。
 // 内容相关信息（哈希/大小/存储路径）不冗余存储，需要时按 FileID 查 File 表。
-type FileUpload struct {
+type FileUploadEntity struct {
 	gorm.Model
 	FileID   uint       `gorm:"column:file_id;not null;default:0;index"`
 	UploadID string     `gorm:"column:upload_id;type:varchar(128);not null;default:'';index"`
@@ -44,7 +44,7 @@ type FileUpload struct {
 	Scene    string     `gorm:"column:scene;type:varchar(64);not null;default:'';index"`
 }
 
-func (FileUpload) TableName() string { return "core_file_upload" }
+func (FileUploadEntity) TableName() string { return "core_file_upload" }
 
 type fileCond struct {
 	gormdao.BaseCond

--- a/gast/_test.go
+++ b/gast/_test.go
@@ -54,6 +54,7 @@ func platformRouter(privateRouter *gin.RouterGroup) {
 	routerGroup.POST("test3") // 3
 	routerGroup.POST("test3") // 3
 	routerGroup.POST("test3") // 3
+	routerGroup.POST("test3") // 3
 	routerGroup.POST("test")
 }
 func NewFunction() {


### PR DESCRIPTION
## 变更内容

### configkv
- store 层从直接使用 `*gorm.DB` 迁移到 `gormdao.Dao` 抽象层
- 将加密创建逻辑从 AdminAPI 层提取到 store 层，精简 AdminAPI 职责
- `ConfigCond` 内嵌 `gormdao.BaseCond` 复用分页/排序/条件构建
- 同步调整测试用例匹配新的签名

### filestore
- 重命名 `File` → `FileEntity`、`FileUpload` → `FileUploadEntity` 避免与内置类型命名冲突

### gast
- 补充测试代码