### PR TITLE
feat(filestore): add package-level singleton for global access

### DIFF
--- a/configkv/kv.go
+++ b/configkv/kv.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	instance *kv
-	adminAPI *AdminAPI
-	once     sync.Once
+	defaultKV *kv
+	adminAPI  *AdminAPI
+	once      sync.Once
 )
 
 type kv struct {
@@ -113,28 +113,28 @@ func Init(db *gorm.DB) {
 		}
 		s := newStore(getDB, registry, c)
 		adminAPI = newAdmin(s)
-		instance = &kv{store: s}
+		defaultKV = &kv{store: s}
 	})
 }
 
 func GetValue(ctx context.Context, group, key string, dest any) error {
-	return instance.GetValue(ctx, group, key, dest)
+	return defaultKV.GetValue(ctx, group, key, dest)
 }
 
 func GetString(ctx context.Context, group, key string) (string, error) {
-	return instance.GetString(ctx, group, key)
+	return defaultKV.GetString(ctx, group, key)
 }
 
 func GetInt64(ctx context.Context, group, key string) (int64, error) {
-	return instance.GetInt64(ctx, group, key)
+	return defaultKV.GetInt64(ctx, group, key)
 }
 
 func GetFloat64(ctx context.Context, group, key string) (float64, error) {
-	return instance.GetFloat64(ctx, group, key)
+	return defaultKV.GetFloat64(ctx, group, key)
 }
 
 func GetBool(ctx context.Context, group, key string) (bool, error) {
-	return instance.GetBool(ctx, group, key)
+	return defaultKV.GetBool(ctx, group, key)
 }
 
 func GetAdmin() *AdminAPI {

--- a/filestore/instance.go
+++ b/filestore/instance.go
@@ -1,0 +1,104 @@
+package filestore
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/morehao/golib/storage"
+	"gorm.io/gorm"
+)
+
+var (
+	defaultFS *FileStore
+	once      sync.Once
+)
+
+// Init 初始化包级单例 FileStore。重复调用是幂等的（仅首次生效）。
+// 初始化失败会 panic，需保证在业务启动阶段调用。
+func Init(db *gorm.DB, st storage.Storage, bucket string, opts ...StoreOption) {
+	once.Do(func() {
+		fs, err := New(db, st, bucket, opts...)
+		if err != nil {
+			panic("init filestore failed: " + err.Error())
+		}
+		defaultFS = fs
+	})
+}
+
+// Get 返回包级单例 FileStore，未调用 Init 时 panic。
+func Get() *FileStore {
+	if defaultFS == nil {
+		panic("filestore: not initialized, call Init first")
+	}
+	return defaultFS
+}
+
+func GetExpiry() time.Duration {
+	return Get().GetExpiry()
+}
+
+func SignSecret() string {
+	return Get().SignSecret()
+}
+
+func IsLocal() bool {
+	return Get().IsLocal()
+}
+
+func Open(ctx context.Context, id uint) (io.ReadCloser, *FileDetail, error) {
+	return Get().Open(ctx, id)
+}
+
+func CheckExist(ctx context.Context, contentHash string) (*FileDetail, bool, error) {
+	return Get().CheckExist(ctx, contentHash)
+}
+
+func RecordUpload(ctx context.Context, req RecordUploadRequest) (*FileDetail, error) {
+	return Get().RecordUpload(ctx, req)
+}
+
+func UploadAndRecord(ctx context.Context, req UploadAndRecordRequest) (*FileDetail, error) {
+	return Get().UploadAndRecord(ctx, req)
+}
+
+func GetFile(ctx context.Context, id uint) (*FileDetail, error) {
+	return Get().GetFile(ctx, id)
+}
+
+func PresignGetFileURL(ctx context.Context, id uint, opts ...PresignOption) (string, error) {
+	return Get().PresignGetFileURL(ctx, id, opts...)
+}
+
+func DeleteFile(ctx context.Context, id uint) error {
+	return Get().DeleteFile(ctx, id)
+}
+
+func GetFileUploadIDByStorageURI(ctx context.Context, storageURI string) (uint, error) {
+	return Get().GetFileUploadIDByStorageURI(ctx, storageURI)
+}
+
+func InitMultipartUpload(ctx context.Context, req InitMultipartUploadRequest) (*FileDetail, error) {
+	return Get().InitMultipartUpload(ctx, req)
+}
+
+func PresignUploadPartURL(ctx context.Context, id uint, partNum int32, opts ...PresignOption) (string, error) {
+	return Get().PresignUploadPartURL(ctx, id, partNum, opts...)
+}
+
+func CompleteMultipartUpload(ctx context.Context, req CompleteMultipartUploadRequest) (*FileDetail, error) {
+	return Get().CompleteMultipartUpload(ctx, req)
+}
+
+func AbortMultipartUpload(ctx context.Context, id uint) error {
+	return Get().AbortMultipartUpload(ctx, id)
+}
+
+func HandlePresignedPut(ctx context.Context, bucket, key string, body io.Reader, contentType string) (*storage.PutObjectResult, error) {
+	return Get().HandlePresignedPut(ctx, bucket, key, body, contentType)
+}
+
+func HandlePresignedGet(ctx context.Context, bucket, key string) (*storage.GetObjectResult, error) {
+	return Get().HandlePresignedGet(ctx, bucket, key)
+}

--- a/filestore/instance_test.go
+++ b/filestore/instance_test.go
@@ -1,0 +1,75 @@
+package filestore
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func resetSingleton() {
+	once = sync.Once{}
+	defaultFS = nil
+}
+
+func TestSingleton_NotInitialized_Panics(t *testing.T) {
+	resetSingleton()
+	require.Panics(t, func() { Get() })
+}
+
+func TestSingleton_InitAndUse(t *testing.T) {
+	resetSingleton()
+	db := newTestDB(t)
+	Init(db, &mockStorage{}, "test-bucket")
+
+	fs := Get()
+	require.NotNil(t, fs)
+
+	detail, err := RecordUpload(context.Background(), RecordUploadRequest{
+		ContentHash: "singleton-hash",
+		Name:        "a.txt",
+		Size:        10,
+		StoragePath: "a.txt",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "singleton-hash", detail.ContentHash)
+
+	found, hit, err := CheckExist(context.Background(), "singleton-hash")
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, "singleton-hash", found.ContentHash)
+}
+
+func TestSingleton_Init_Idempotent(t *testing.T) {
+	resetSingleton()
+	db := newTestDB(t)
+	Init(db, &mockStorage{}, "test-bucket")
+	fs1 := Get()
+
+	Init(db, &mockStorage{}, "other-bucket")
+	fs2 := Get()
+	require.Same(t, fs1, fs2)
+}
+
+func TestSingleton_InitFailure_Panics(t *testing.T) {
+	resetSingleton()
+
+	dbfile := filepath.Join(t.TempDir(), "readonly.db")
+	createDB, err := gorm.Open(sqlite.Open(dbfile), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, createDB.Exec("CREATE TABLE placeholder (id INTEGER PRIMARY KEY);").Error)
+	sqlDB, err := createDB.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	roDB, err := gorm.Open(sqlite.Open("file:"+dbfile+"?mode=ro&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.Panics(t, func() {
+		Init(roDB, &mockStorage{}, "test-bucket")
+	})
+}

--- a/glog/init.go
+++ b/glog/init.go
@@ -5,5 +5,5 @@ func init() {
 	if err != nil {
 		return
 	}
-	defaultLoggerInstance = logger
+	defaultLogger = logger
 }

--- a/glog/instance.go
+++ b/glog/instance.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-var defaultLoggerInstance Logger
+var defaultLogger Logger
 
 var registeredFactories = map[LoggerType]LoggerFactory{}
 
@@ -18,7 +18,7 @@ func InitLogger(cfg *LogConfig, opts ...Option) error {
 	if err != nil {
 		return err
 	}
-	defaultLoggerInstance = logger
+	defaultLogger = logger
 	return nil
 }
 
@@ -42,8 +42,8 @@ func newLogger(cfg *LogConfig, opts ...Option) (Logger, error) {
 }
 
 func getDefaultLogger() (Logger, error) {
-	if defaultLoggerInstance != nil {
-		return defaultLoggerInstance, nil
+	if defaultLogger != nil {
+		return defaultLogger, nil
 	}
 	return newLogger(GetDefaultLogConfig())
 }
@@ -218,17 +218,17 @@ func Fatalw(ctx context.Context, msg string, kvs ...any) {
 }
 
 func Close() error {
-	if defaultLoggerInstance == nil {
+	if defaultLogger == nil {
 		return nil
 	}
-	return defaultLoggerInstance.Close()
+	return defaultLogger.Close()
 }
 
 func ensureLogger() Logger {
-	if defaultLoggerInstance == nil {
+	if defaultLogger == nil {
 		return newNopLogger()
 	}
-	return defaultLoggerInstance
+	return defaultLogger
 }
 
 // logEntryFallback 处理未实现 CallerOffsetLogger 的第三方 driver。

--- a/glog/logger.go
+++ b/glog/logger.go
@@ -36,24 +36,24 @@ func newNopLogger() *nopLogger {
 	return &nopLogger{}
 }
 
-func (n *nopLogger) Debug(ctx context.Context, args ...any)                   {}
-func (n *nopLogger) Debugf(ctx context.Context, format string, kvs ...any)     {}
-func (n *nopLogger) Debugw(ctx context.Context, msg string, kvs ...any)        {}
-func (n *nopLogger) Info(ctx context.Context, args ...any)                    {}
-func (n *nopLogger) Infof(ctx context.Context, format string, kvs ...any)      {}
-func (n *nopLogger) Infow(ctx context.Context, msg string, kvs ...any)         {}
-func (n *nopLogger) Warn(ctx context.Context, args ...any)                    {}
-func (n *nopLogger) Warnf(ctx context.Context, format string, kvs ...any)      {}
-func (n *nopLogger) Warnw(ctx context.Context, msg string, kvs ...any)         {}
-func (n *nopLogger) Error(ctx context.Context, args ...any)                   {}
-func (n *nopLogger) Errorf(ctx context.Context, format string, kvs ...any)     {}
-func (n *nopLogger) Errorw(ctx context.Context, msg string, kvs ...any)        {}
-func (n *nopLogger) Panic(ctx context.Context, args ...any)                   {}
-func (n *nopLogger) Panicf(ctx context.Context, format string, args ...any)    {}
-func (n *nopLogger) Panicw(ctx context.Context, msg string, kvs ...any)        {}
-func (n *nopLogger) Fatal(ctx context.Context, args ...any)                   {}
-func (n *nopLogger) Fatalf(ctx context.Context, format string, args ...any)    {}
-func (n *nopLogger) Fatalw(ctx context.Context, msg string, kvs ...any)        {}
-func (n *nopLogger) With(kvs ...any) Logger                                   { return n }
-func (n *nopLogger) Close() error                                             { return nil }
-func (n *nopLogger) GetConfig() *LogConfig                                    { return nil }
+func (n *nopLogger) Debug(ctx context.Context, args ...any)                 {}
+func (n *nopLogger) Debugf(ctx context.Context, format string, kvs ...any)  {}
+func (n *nopLogger) Debugw(ctx context.Context, msg string, kvs ...any)     {}
+func (n *nopLogger) Info(ctx context.Context, args ...any)                  {}
+func (n *nopLogger) Infof(ctx context.Context, format string, kvs ...any)   {}
+func (n *nopLogger) Infow(ctx context.Context, msg string, kvs ...any)      {}
+func (n *nopLogger) Warn(ctx context.Context, args ...any)                  {}
+func (n *nopLogger) Warnf(ctx context.Context, format string, kvs ...any)   {}
+func (n *nopLogger) Warnw(ctx context.Context, msg string, kvs ...any)      {}
+func (n *nopLogger) Error(ctx context.Context, args ...any)                 {}
+func (n *nopLogger) Errorf(ctx context.Context, format string, kvs ...any)  {}
+func (n *nopLogger) Errorw(ctx context.Context, msg string, kvs ...any)     {}
+func (n *nopLogger) Panic(ctx context.Context, args ...any)                 {}
+func (n *nopLogger) Panicf(ctx context.Context, format string, args ...any) {}
+func (n *nopLogger) Panicw(ctx context.Context, msg string, kvs ...any)     {}
+func (n *nopLogger) Fatal(ctx context.Context, args ...any)                 {}
+func (n *nopLogger) Fatalf(ctx context.Context, format string, args ...any) {}
+func (n *nopLogger) Fatalw(ctx context.Context, msg string, kvs ...any)     {}
+func (n *nopLogger) With(kvs ...any) Logger                                 { return n }
+func (n *nopLogger) Close() error                                           { return nil }
+func (n *nopLogger) GetConfig() *LogConfig                                  { return nil }

--- a/gvalidate/validate.go
+++ b/gvalidate/validate.go
@@ -56,14 +56,14 @@ func AsErrors(err error) (Errors, bool) {
 
 // ── 内部单例 ────────────────────────────────────────────────────────
 
-type instance struct {
+type gvalidator struct {
 	once     sync.Once
 	validate *validator.Validate
 	trans    unTrans.Translator
 	initErr  error
 }
 
-func (ins *instance) init() error {
+func (ins *gvalidator) init() error {
 	ins.once.Do(func() {
 		v := validator.New()
 		uni := unTrans.New(zh_Hans_CN.New())
@@ -94,7 +94,7 @@ func (ins *instance) init() error {
 	return ins.initErr
 }
 
-func (ins *instance) check(data any) error {
+func (ins *gvalidator) check(data any) error {
 	if err := ins.init(); err != nil {
 		return err
 	}
@@ -116,23 +116,23 @@ func (ins *instance) check(data any) error {
 	return result
 }
 
-func (ins *instance) registerValidation(tag string, fn validator.Func) error {
+func (ins *gvalidator) registerValidation(tag string, fn validator.Func) error {
 	if err := ins.init(); err != nil {
 		return err
 	}
 	return ins.validate.RegisterValidation(tag, fn)
 }
 
-var std = &instance{}
+var defaultGValidator = &gvalidator{}
 
 // ── 公开 API ────────────────────────────────────────────────────────
 
 // Check 校验结构体，通过返回 nil，失败返回 Errors
 func Check(data any) error {
-	return std.check(data)
+	return defaultGValidator.check(data)
 }
 
 // RegisterValidation 注册自定义校验规则
 func RegisterValidation(tag string, fn validator.Func) error {
-	return std.registerValidation(tag, fn)
+	return defaultGValidator.registerValidation(tag, fn)
 }


### PR DESCRIPTION
## 变更内容
为 filestore 增加包级单例，与 configkv/glog/gvalidate 的模式保持一致：

- 新增 `filestore/instance.go`：`Init`/`Get` 包级单例，暴露全部方法代理
- 新增 `filestore/instance_test.go`：单例初始化、幂等性、未初始化 panic、初始化失败 panic 测试
- 统一各模块默认实例命名规范（`defaultKV`/`defaultLogger`/`defaultGValidator`）
- gofmt 对齐 glog logger.go 格式