### PR TITLE
refactor(gormplugin): move out of biz and generalize to scope condition plugin

### DIFF
--- a/dbaccess/gormplugin/README.md
+++ b/dbaccess/gormplugin/README.md
@@ -1,0 +1,93 @@
+# gormplugin
+
+`gormplugin` 是一个 GORM 多租户插件，通过在 GORM 的 Query、Update、Delete 回调前自动注入租户过滤条件（如 `` `table`.`tenant_id` = ? ``），实现数据访问的租户隔离。
+
+---
+
+## 特性
+
+- **自动注入租户条件**：在查询、更新、删除操作前自动追加租户过滤条件，业务代码无需手动拼接。
+- **字段名可配置**：租户字段名可通过 `WithField` 指定，默认为 `tenant_id`。
+- **从 context 提取租户值**：通过 `WithExtractFunc` 自定义从 `context.Context` 中提取租户值的方式。
+- **表级跳过**：通过 `WithSkipTables` 指定需要跳过的表，这些表的操作不会注入租户条件。
+- **单次操作跳过**：通过 `Skip` 在单次操作中临时跳过租户条件注入。
+
+---
+
+## 安装
+
+```bash
+import "github.com/morehao/golib/dbaccess/gormplugin"
+```
+
+---
+
+## API 说明
+
+- `New(opts ...Option) *ScopePlugin` 创建一个新的插件实例，默认租户字段名为 `tenant_id`。
+- `WithField(name string) Option` 设置租户字段名。
+- `WithSkipTables(tables []string) Option` 设置跳过的表名列表（匹配时会去除反引号、schema 前缀并转为小写）。
+- `WithExtractFunc(fn func(context.Context) (any, bool)) Option` 设置租户值提取函数，从 context 中返回租户值及是否存在。
+- `Skip(db *gorm.DB) *gorm.DB` 对当前操作跳过租户条件注入。
+
+---
+
+## 使用示例
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/morehao/golib/dbaccess/gormplugin"
+	"gorm.io/gorm"
+)
+
+type testModel struct {
+	ID       uint
+	TenantID uint
+	Name     string
+}
+
+func main() {
+	// 创建插件：租户字段为 tenant_id，从 context 的 test_tenant key 提取租户值
+	plugin := gormplugin.New(
+		gormplugin.WithField("tenant_id"),
+		gormplugin.WithExtractFunc(func(ctx context.Context) (any, bool) {
+			return ctx.Value("test_tenant"), true
+		}),
+	)
+
+	// 注册到 GORM
+	if err := db.Use(plugin); err != nil {
+		panic(err)
+	}
+
+	// 业务代码无需手动加租户条件
+	ctx := context.WithValue(context.Background(), "test_tenant", uint(1))
+	var out []testModel
+	if err := db.WithContext(ctx).Find(&out).Error; err != nil {
+		panic(err)
+	}
+
+	// 单次操作跳过租户条件注入
+	var all []testModel
+	if err := gormplugin.Skip(db.WithContext(ctx)).Find(&all).Error; err != nil {
+		panic(err)
+	}
+}
+```
+
+---
+
+## 工作原理与注意事项
+
+- 插件通过注册 GORM 回调，在 `query`、`update`、`delete` 三类操作之前执行租户条件注入。
+- **Create 操作不会注入**：插入时租户字段由业务代码显式赋值。
+- 以下情况不会注入租户条件：
+  - 未配置 `WithExtractFunc`。
+  - `extractFunc` 返回的第二个值为 `false`（表示无租户值）。
+  - 当前操作的 `Statement` 或 `Statement.Context` 为空。
+  - 表名命中 `WithSkipTables` 配置的跳过列表，或操作调用了 `Skip`。
+- 表名匹配时会对表名做规范化处理：去除首尾空格与反引号、去掉 schema 前缀（`.` 后的部分）、统一转为小写。

--- a/dbaccess/gormplugin/scope.go
+++ b/dbaccess/gormplugin/scope.go
@@ -5,21 +5,29 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/morehao/golib/biz/gcontext"
-	"github.com/morehao/golib/gutil"
 	"gorm.io/gorm"
 )
 
-type Plugin struct {
-	skipTablesMap map[string]struct{}
-	TenantIDField string
+const SkipKey = "gorm:condition:skip"
+
+type ScopePlugin struct {
+	fieldName   string
+	skipTables  map[string]struct{}
+	extractFunc func(context.Context) (any, bool)
 }
 
 type Option func(*options)
 
 type options struct {
-	skipTablesMap map[string]struct{}
-	tenantIDField string
+	fieldName   string
+	skipTables  map[string]struct{}
+	extractFunc func(context.Context) (any, bool)
+}
+
+func WithField(name string) Option {
+	return func(o *options) {
+		o.fieldName = name
+	}
 }
 
 func WithSkipTables(tables []string) Option {
@@ -27,44 +35,45 @@ func WithSkipTables(tables []string) Option {
 		for _, t := range tables {
 			normalized := normalizeTableName(t)
 			if normalized != "" {
-				o.skipTablesMap[normalized] = struct{}{}
+				o.skipTables[normalized] = struct{}{}
 			}
 		}
 	}
 }
 
-func WithTenantIDField(field string) Option {
+func WithExtractFunc(fn func(context.Context) (any, bool)) Option {
 	return func(o *options) {
-		o.tenantIDField = field
+		o.extractFunc = fn
 	}
 }
 
-func New(opts ...Option) *Plugin {
+func New(opts ...Option) *ScopePlugin {
 	o := &options{
-		skipTablesMap: make(map[string]struct{}),
-		tenantIDField: "tenant_id",
+		fieldName:  "tenant_id",
+		skipTables: make(map[string]struct{}),
 	}
 	for _, opt := range opts {
 		opt(o)
 	}
-	return &Plugin{
-		skipTablesMap: o.skipTablesMap,
-		TenantIDField: o.tenantIDField,
+	return &ScopePlugin{
+		fieldName:   o.fieldName,
+		skipTables:  o.skipTables,
+		extractFunc: o.extractFunc,
 	}
 }
 
-func (p *Plugin) Name() string { return "tenant_scope_plugin" }
+func (p *ScopePlugin) Name() string { return "scope_condition_plugin" }
 
-func (p *Plugin) Initialize(db *gorm.DB) error {
+func (p *ScopePlugin) Initialize(db *gorm.DB) error {
 	callbacks := []struct {
 		name   string
 		typ    string
 		before string
 		fn     func(*gorm.DB)
 	}{
-		{"tenant:query", "query", "gorm:query", p.addTenantScope},
-		{"tenant:update", "update", "gorm:update", p.addTenantScope},
-		{"tenant:delete", "delete", "gorm:delete", p.addTenantScope},
+		{"gormplugin:query", "query", "gorm:query", p.addScope},
+		{"gormplugin:update", "update", "gorm:update", p.addScope},
+		{"gormplugin:delete", "delete", "gorm:delete", p.addScope},
 	}
 
 	for _, cb := range callbacks {
@@ -84,9 +93,15 @@ func (p *Plugin) Initialize(db *gorm.DB) error {
 	return nil
 }
 
-func (p *Plugin) addTenantScope(db *gorm.DB) {
+func (p *ScopePlugin) addScope(db *gorm.DB) {
 	if db.Statement == nil || db.Statement.Context == nil {
 		return
+	}
+
+	if v, ok := db.Get(SkipKey); ok {
+		if skip, ok := v.(bool); ok && skip {
+			return
+		}
 	}
 
 	tableName := resolveTableName(db)
@@ -98,31 +113,29 @@ func (p *Plugin) addTenantScope(db *gorm.DB) {
 		return
 	}
 
-	tenantID, ok := getTenantID(db.Statement.Context)
+	if p.extractFunc == nil {
+		return
+	}
+
+	value, ok := p.extractFunc(db.Statement.Context)
 	if !ok {
 		return
 	}
 
-	db.Statement.Where(fmt.Sprintf("`%s`.%s = ?", tableName, p.TenantIDField), tenantID)
+	db.Statement.Where(fmt.Sprintf("`%s`.%s = ?", tableName, p.fieldName), value)
 }
 
-func (p *Plugin) isSkipped(tableName string) bool {
+func (p *ScopePlugin) isSkipped(tableName string) bool {
 	normalized := normalizeTableName(tableName)
 	if normalized == "" {
 		return false
 	}
-	_, ok := p.skipTablesMap[normalized]
+	_, ok := p.skipTables[normalized]
 	return ok
 }
 
-func getTenantID(ctx context.Context) (uint, bool) {
-	if ctx == nil {
-		return 0, false
-	}
-
-	v := ctx.Value(gcontext.KeyTenantID)
-	tenantID := uint(gutil.VToInt64(v))
-	return tenantID, tenantID > 0
+func Skip(db *gorm.DB) *gorm.DB {
+	return db.Set(SkipKey, true)
 }
 
 func normalizeTableName(tableName string) string {

--- a/dbaccess/gormplugin/scope_test.go
+++ b/dbaccess/gormplugin/scope_test.go
@@ -1,0 +1,149 @@
+package gormplugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type testModel struct {
+	ID       uint
+	TenantID uint
+	Name     string
+}
+
+func (testModel) TableName() string { return "test_models" }
+
+type testCompanyModel struct {
+	ID        uint
+	CompanyID string
+	Name      string
+}
+
+func (testCompanyModel) TableName() string { return "test_company_models" }
+
+func setupTestDB(t *testing.T, tables ...any) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(tables...))
+	return db
+}
+
+func TestScopePlugin_InjectCondition(t *testing.T) {
+	db := setupTestDB(t, &testModel{})
+	plugin := New(
+		WithField("tenant_id"),
+		WithExtractFunc(func(ctx context.Context) (any, bool) {
+			return ctx.Value("test_tenant"), true
+		}),
+	)
+	require.NoError(t, db.Use(plugin))
+
+	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)
+	require.NoError(t, db.Create(&testModel{TenantID: 2, Name: "b"}).Error)
+
+	ctx := context.WithValue(context.Background(), "test_tenant", uint(1))
+	var out []testModel
+	require.NoError(t, db.WithContext(ctx).Find(&out).Error)
+	require.Len(t, out, 1)
+	require.Equal(t, "a", out[0].Name)
+}
+
+func TestScopePlugin_FieldConfigurable(t *testing.T) {
+	db := setupTestDB(t, &testCompanyModel{})
+	plugin := New(
+		WithField("company_id"),
+		WithExtractFunc(func(ctx context.Context) (any, bool) {
+			return ctx.Value("test_company"), true
+		}),
+	)
+	require.NoError(t, db.Use(plugin))
+
+	require.NoError(t, db.Create(&testCompanyModel{CompanyID: "co_a", Name: "a"}).Error)
+	require.NoError(t, db.Create(&testCompanyModel{CompanyID: "co_b", Name: "b"}).Error)
+
+	ctx := context.WithValue(context.Background(), "test_company", "co_b")
+	var out []testCompanyModel
+	require.NoError(t, db.WithContext(ctx).Find(&out).Error)
+	require.Len(t, out, 1)
+	require.Equal(t, "b", out[0].Name)
+}
+
+func TestScopePlugin_StaticSkipTable(t *testing.T) {
+	db := setupTestDB(t, &testModel{})
+	plugin := New(
+		WithField("tenant_id"),
+		WithSkipTables([]string{"test_models"}),
+		WithExtractFunc(func(ctx context.Context) (any, bool) {
+			return ctx.Value("test_tenant"), true
+		}),
+	)
+	require.NoError(t, db.Use(plugin))
+
+	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)
+	require.NoError(t, db.Create(&testModel{TenantID: 2, Name: "b"}).Error)
+
+	ctx := context.WithValue(context.Background(), "test_tenant", uint(1))
+	var out []testModel
+	require.NoError(t, db.WithContext(ctx).Find(&out).Error)
+	require.Len(t, out, 2)
+}
+
+func TestScopePlugin_Skip(t *testing.T) {
+	db := setupTestDB(t, &testModel{})
+	plugin := New(
+		WithField("tenant_id"),
+		WithExtractFunc(func(ctx context.Context) (any, bool) {
+			return ctx.Value("test_tenant"), true
+		}),
+	)
+	require.NoError(t, db.Use(plugin))
+
+	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)
+	require.NoError(t, db.Create(&testModel{TenantID: 2, Name: "b"}).Error)
+
+	ctx := context.WithValue(context.Background(), "test_tenant", uint(1))
+	var out []testModel
+	require.NoError(t, Skip(db.WithContext(ctx)).Find(&out).Error)
+	require.Len(t, out, 2)
+}
+
+func TestScopePlugin_ExtractFuncMissing(t *testing.T) {
+	db := setupTestDB(t, &testModel{})
+	plugin := New(WithField("tenant_id"))
+	require.NoError(t, db.Use(plugin))
+
+	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)
+	require.NoError(t, db.Create(&testModel{TenantID: 2, Name: "b"}).Error)
+
+	ctx := context.WithValue(context.Background(), "test_tenant", uint(1))
+	var out []testModel
+	require.NoError(t, db.WithContext(ctx).Find(&out).Error)
+	require.Len(t, out, 2)
+}
+
+func TestScopePlugin_ExtractFuncFalse(t *testing.T) {
+	db := setupTestDB(t, &testModel{})
+	plugin := New(
+		WithField("tenant_id"),
+		WithExtractFunc(func(ctx context.Context) (any, bool) {
+			return nil, false
+		}),
+	)
+	require.NoError(t, db.Use(plugin))
+
+	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)
+	require.NoError(t, db.Create(&testModel{TenantID: 2, Name: "b"}).Error)
+
+	ctx := context.WithValue(context.Background(), "test_tenant", uint(1))
+	var out []testModel
+	require.NoError(t, db.WithContext(ctx).Find(&out).Error)
+	require.Len(t, out, 2)
+}


### PR DESCRIPTION
## Summary

将 `biz/gormplugin` 移动到 `dbaccess/gormplugin`，并重构为通用的 context 条件注入插件（不再绑定租户语义）。

## Changes

- **移动**：`biz/gormplugin/tenant.go` → `dbaccess/gormplugin/scope.go`
- **通用化**：
  - `ScopePlugin` 取代原 `Plugin`，删除 gcontext/gutil 依赖
  - `WithField` 支持任意字段名（`tenant_id` / `company_id` 等）
  - `WithExtractFunc` 从 context 提取值，类型为 `any`（支持 uint/int64/string）
  - `WithSkipTables` 静态跳过表
  - `Skip(db)` 单次查询级跳过（基于 `db.Set`/`db.Get`，gorm 官方插件惯例）
- **测试**：新增 `scope_test.go`，覆盖正常注入、字段名可配、string 值、静态跳过、单次跳过、extractFunc 缺失降级

## 破坏性变更

- 引用 `biz/gormplugin` 的调用方需改 import 路径并迁移到新 API（仓库内当前无其他引用）

## Verification

- `go build ./...` 通过
- `go test ./dbaccess/gormplugin/...` 全部通过