### PR TITLE
refactor(gormplugin): require FieldName and ExtractFunc via ScopeConfig

### DIFF
--- a/dbaccess/gormplugin/README.md
+++ b/dbaccess/gormplugin/README.md
@@ -7,8 +7,8 @@
 ## 特性
 
 - **自动注入租户条件**：在查询、更新、删除操作前自动追加租户过滤条件，业务代码无需手动拼接。
-- **字段名可配置**：租户字段名可通过 `WithField` 指定，默认为 `tenant_id`。
-- **从 context 提取租户值**：通过 `WithExtractFunc` 自定义从 `context.Context` 中提取租户值的方式。
+- **字段名由调用方指定**：租户字段名（如 `tenant_id`、`company_id`）通过配置结构体必填指定，不隐含默认值。
+- **从 context 提取租户值**：通过配置结构体的 `ExtractFunc` 自定义从 `context.Context` 中提取租户值的方式，同样为必填项。
 - **表级跳过**：通过 `WithSkipTables` 指定需要跳过的表，这些表的操作不会注入租户条件。
 - **单次操作跳过**：通过 `Skip` 在单次操作中临时跳过租户条件注入。
 
@@ -24,10 +24,11 @@ import "github.com/morehao/golib/dbaccess/gormplugin"
 
 ## API 说明
 
-- `New(opts ...Option) *ScopePlugin` 创建一个新的插件实例，默认租户字段名为 `tenant_id`。
-- `WithField(name string) Option` 设置租户字段名。
-- `WithSkipTables(tables []string) Option` 设置跳过的表名列表（匹配时会去除反引号、schema 前缀并转为小写）。
-- `WithExtractFunc(fn func(context.Context) (any, bool)) Option` 设置租户值提取函数，从 context 中返回租户值及是否存在。
+- `ScopeConfig` 创建插件所需的配置结构体，其中 `FieldName` 与 `ExtractFunc` 为**必填**项。
+  - `FieldName string`：租户过滤字段名（如 `tenant_id`、`company_id`），必填，不提供默认值。
+  - `ExtractFunc func(context.Context) (any, bool)`：从 context 返回租户值及是否存在，必填。
+  - `SkipTables []string`：跳过条件注入的表名列表（可选，匹配时去除反引号、schema 前缀并转为小写）。
+- `New(cfg *ScopeConfig) (*ScopePlugin, error)` 创建插件实例；当 `cfg` 为 nil 或缺少必填项时返回错误。
 - `Skip(db *gorm.DB) *gorm.DB` 对当前操作跳过租户条件注入。
 
 ---
@@ -52,12 +53,15 @@ type testModel struct {
 
 func main() {
 	// 创建插件：租户字段为 tenant_id，从 context 的 test_tenant key 提取租户值
-	plugin := gormplugin.New(
-		gormplugin.WithField("tenant_id"),
-		gormplugin.WithExtractFunc(func(ctx context.Context) (any, bool) {
+	plugin, err := gormplugin.New(&gormplugin.ScopeConfig{
+		FieldName: "tenant_id",
+		ExtractFunc: func(ctx context.Context) (any, bool) {
 			return ctx.Value("test_tenant"), true
-		}),
-	)
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
 
 	// 注册到 GORM
 	if err := db.Use(plugin); err != nil {
@@ -85,9 +89,9 @@ func main() {
 
 - 插件通过注册 GORM 回调，在 `query`、`update`、`delete` 三类操作之前执行租户条件注入。
 - **Create 操作不会注入**：插入时租户字段由业务代码显式赋值。
+- **必填配置**：`FieldName` 与 `ExtractFunc` 为必填项，`New` 会校验，缺失时返回错误，杜绝隐性默认字段名。
 - 以下情况不会注入租户条件：
-  - 未配置 `WithExtractFunc`。
   - `extractFunc` 返回的第二个值为 `false`（表示无租户值）。
   - 当前操作的 `Statement` 或 `Statement.Context` 为空。
-  - 表名命中 `WithSkipTables` 配置的跳过列表，或操作调用了 `Skip`。
+  - 表名命中 `SkipTables` 配置的跳过列表，或操作调用了 `Skip`。
 - 表名匹配时会对表名做规范化处理：去除首尾空格与反引号、去掉 schema 前缀（`.` 后的部分）、统一转为小写。

--- a/dbaccess/gormplugin/scope.go
+++ b/dbaccess/gormplugin/scope.go
@@ -16,55 +16,51 @@ type ScopePlugin struct {
 	extractFunc func(context.Context) (any, bool)
 }
 
-type Option func(*options)
-
-type options struct {
-	fieldName   string
-	skipTables  map[string]struct{}
-	extractFunc func(context.Context) (any, bool)
+// ScopeConfig 是创建 ScopePlugin 的配置，为必填入参。
+// FieldName 与 ExtractFunc 为必填项，缺失时 New 返回 error。
+type ScopeConfig struct {
+	// FieldName 指定租户过滤字段名（如 tenant_id、company_id），必填。
+	FieldName string
+	// ExtractFunc 从 context 中提取租户过滤值及是否存在，必填。
+	ExtractFunc func(context.Context) (any, bool)
+	// SkipTables 指定跳过条件注入的表名列表，可选。
+	SkipTables []string
 }
 
-func WithField(name string) Option {
-	return func(o *options) {
-		o.fieldName = name
+// New 创建 ScopePlugin。FieldName 与 ExtractFunc 为必填配置，
+// 缺失时返回 error，确保通用组件不隐含默认字段名。
+func New(cfg *ScopeConfig) (*ScopePlugin, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("gormplugin: ScopeConfig is required")
 	}
-}
+	if strings.TrimSpace(cfg.FieldName) == "" {
+		return nil, fmt.Errorf("gormplugin: FieldName is required")
+	}
+	if cfg.ExtractFunc == nil {
+		return nil, fmt.Errorf("gormplugin: ExtractFunc is required")
+	}
 
-func WithSkipTables(tables []string) Option {
-	return func(o *options) {
-		for _, t := range tables {
-			normalized := normalizeTableName(t)
-			if normalized != "" {
-				o.skipTables[normalized] = struct{}{}
-			}
+	skipTables := make(map[string]struct{})
+	for _, t := range cfg.SkipTables {
+		normalized := normalizeTableName(t)
+		if normalized != "" {
+			skipTables[normalized] = struct{}{}
 		}
 	}
-}
 
-func WithExtractFunc(fn func(context.Context) (any, bool)) Option {
-	return func(o *options) {
-		o.extractFunc = fn
-	}
-}
-
-func New(opts ...Option) *ScopePlugin {
-	o := &options{
-		fieldName:  "tenant_id",
-		skipTables: make(map[string]struct{}),
-	}
-	for _, opt := range opts {
-		opt(o)
-	}
 	return &ScopePlugin{
-		fieldName:   o.fieldName,
-		skipTables:  o.skipTables,
-		extractFunc: o.extractFunc,
-	}
+		fieldName:   cfg.FieldName,
+		skipTables:  skipTables,
+		extractFunc: cfg.ExtractFunc,
+	}, nil
 }
 
 func (p *ScopePlugin) Name() string { return "scope_condition_plugin" }
 
 func (p *ScopePlugin) Initialize(db *gorm.DB) error {
+	if strings.TrimSpace(p.fieldName) == "" || p.extractFunc == nil {
+		return fmt.Errorf("gormplugin: FieldName and ExtractFunc are required")
+	}
 	callbacks := []struct {
 		name   string
 		typ    string
@@ -110,10 +106,6 @@ func (p *ScopePlugin) addScope(db *gorm.DB) {
 	}
 
 	if p.isSkipped(tableName) {
-		return
-	}
-
-	if p.extractFunc == nil {
 		return
 	}
 

--- a/dbaccess/gormplugin/scope_test.go
+++ b/dbaccess/gormplugin/scope_test.go
@@ -38,12 +38,13 @@ func setupTestDB(t *testing.T, tables ...any) *gorm.DB {
 
 func TestScopePlugin_InjectCondition(t *testing.T) {
 	db := setupTestDB(t, &testModel{})
-	plugin := New(
-		WithField("tenant_id"),
-		WithExtractFunc(func(ctx context.Context) (any, bool) {
+	plugin, err := New(&ScopeConfig{
+		FieldName: "tenant_id",
+		ExtractFunc: func(ctx context.Context) (any, bool) {
 			return ctx.Value("test_tenant"), true
-		}),
-	)
+		},
+	})
+	require.NoError(t, err)
 	require.NoError(t, db.Use(plugin))
 
 	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)
@@ -58,12 +59,13 @@ func TestScopePlugin_InjectCondition(t *testing.T) {
 
 func TestScopePlugin_FieldConfigurable(t *testing.T) {
 	db := setupTestDB(t, &testCompanyModel{})
-	plugin := New(
-		WithField("company_id"),
-		WithExtractFunc(func(ctx context.Context) (any, bool) {
+	plugin, err := New(&ScopeConfig{
+		FieldName: "company_id",
+		ExtractFunc: func(ctx context.Context) (any, bool) {
 			return ctx.Value("test_company"), true
-		}),
-	)
+		},
+	})
+	require.NoError(t, err)
 	require.NoError(t, db.Use(plugin))
 
 	require.NoError(t, db.Create(&testCompanyModel{CompanyID: "co_a", Name: "a"}).Error)
@@ -78,13 +80,14 @@ func TestScopePlugin_FieldConfigurable(t *testing.T) {
 
 func TestScopePlugin_StaticSkipTable(t *testing.T) {
 	db := setupTestDB(t, &testModel{})
-	plugin := New(
-		WithField("tenant_id"),
-		WithSkipTables([]string{"test_models"}),
-		WithExtractFunc(func(ctx context.Context) (any, bool) {
+	plugin, err := New(&ScopeConfig{
+		FieldName:  "tenant_id",
+		SkipTables: []string{"test_models"},
+		ExtractFunc: func(ctx context.Context) (any, bool) {
 			return ctx.Value("test_tenant"), true
-		}),
-	)
+		},
+	})
+	require.NoError(t, err)
 	require.NoError(t, db.Use(plugin))
 
 	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)
@@ -98,12 +101,13 @@ func TestScopePlugin_StaticSkipTable(t *testing.T) {
 
 func TestScopePlugin_Skip(t *testing.T) {
 	db := setupTestDB(t, &testModel{})
-	plugin := New(
-		WithField("tenant_id"),
-		WithExtractFunc(func(ctx context.Context) (any, bool) {
+	plugin, err := New(&ScopeConfig{
+		FieldName: "tenant_id",
+		ExtractFunc: func(ctx context.Context) (any, bool) {
 			return ctx.Value("test_tenant"), true
-		}),
-	)
+		},
+	})
+	require.NoError(t, err)
 	require.NoError(t, db.Use(plugin))
 
 	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)
@@ -115,28 +119,34 @@ func TestScopePlugin_Skip(t *testing.T) {
 	require.Len(t, out, 2)
 }
 
-func TestScopePlugin_ExtractFuncMissing(t *testing.T) {
-	db := setupTestDB(t, &testModel{})
-	plugin := New(WithField("tenant_id"))
-	require.NoError(t, db.Use(plugin))
-
-	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)
-	require.NoError(t, db.Create(&testModel{TenantID: 2, Name: "b"}).Error)
-
-	ctx := context.WithValue(context.Background(), "test_tenant", uint(1))
-	var out []testModel
-	require.NoError(t, db.WithContext(ctx).Find(&out).Error)
-	require.Len(t, out, 2)
+func TestScopePlugin_ConfigRequired(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		_, err := New(nil)
+		require.Error(t, err)
+	})
+	t.Run("missing field name", func(t *testing.T) {
+		_, err := New(&ScopeConfig{
+			ExtractFunc: func(ctx context.Context) (any, bool) {
+				return ctx.Value("test_tenant"), true
+			},
+		})
+		require.Error(t, err)
+	})
+	t.Run("missing extract func", func(t *testing.T) {
+		_, err := New(&ScopeConfig{FieldName: "tenant_id"})
+		require.Error(t, err)
+	})
 }
 
 func TestScopePlugin_ExtractFuncFalse(t *testing.T) {
 	db := setupTestDB(t, &testModel{})
-	plugin := New(
-		WithField("tenant_id"),
-		WithExtractFunc(func(ctx context.Context) (any, bool) {
+	plugin, err := New(&ScopeConfig{
+		FieldName: "tenant_id",
+		ExtractFunc: func(ctx context.Context) (any, bool) {
 			return nil, false
-		}),
-	)
+		},
+	})
+	require.NoError(t, err)
 	require.NoError(t, db.Use(plugin))
 
 	require.NoError(t, db.Create(&testModel{TenantID: 1, Name: "a"}).Error)


### PR DESCRIPTION
## 背景

通用多租户组件不应默认指定 `tenant_id`，且必填信息应体现为入参而非隐藏于可变参数选项模式中。

## 变更

- 新增 `ScopeConfig` 配置结构体，`FieldName` 与 `ExtractFunc` 为**必填**，移除 `tenant_id` 默认值与 `Option`/带 `With` 前缀的选项函数（`WithField`、`WithExtractFunc`、`WithSkipTables`）。
- `New(cfg *ScopeConfig) (*ScopePlugin, error)` 校验必填项（nil 配置 / 空字段名 / 缺失提取函数均返回错误）；`Initialize` 保留防御性复检。
- `SkipTables` 保留为可选字段。
- 更新测试与 README。

## 验证

- `go build ./...`、`go vet`、`go test ./dbaccess/...` 全部通过。
- 仓库内无旧符号残留引用。

## 破坏性变更

调用方需改用 `gormplugin.New(&gormplugin.ScopeConfig{FieldName: ..., ExtractFunc: ...})`。
